### PR TITLE
fix: add reference for SkyFrost.Base.Model

### DIFF
--- a/ResoniteIPv6Mod/ResoniteIPv6Mod.cs
+++ b/ResoniteIPv6Mod/ResoniteIPv6Mod.cs
@@ -24,7 +24,7 @@ namespace ResoniteIPv6Mod
     {
         public const string Name = "ResoniteIPv6Mod";
         public const string Author = "Rucio";
-        public const string Version = "3.1.0";
+        public const string Version = "3.1.1";
         public const string Link = "https://github.com/bontebok/ResoniteIPv6Mod";
         public const string GUID = "com.ruciomods.resoniteipv6mod";
     }

--- a/ResoniteIPv6Mod/ResoniteIPv6Mod.csproj
+++ b/ResoniteIPv6Mod/ResoniteIPv6Mod.csproj
@@ -35,6 +35,9 @@
     <Reference Include="SkyFrost.Base">
       <HintPath>$(ResonitePath)Resonite_Data\Managed\SkyFrost.Base.dll</HintPath>
     </Reference>
+    <Reference Include="SkyFrost.Base.Models">
+      <HintPath>$(ResonitePath)Resonite_Data\Managed\SkyFrost.Base.Models.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>$(ResonitePath)Resonite_Data\Managed\System.ValueTuple.dll</HintPath>
     </Reference>


### PR DESCRIPTION
This will fix issues with the mod due to the models moving from the SkyFrost.Base assembly to the SkyFrost.Base.Models assembly.